### PR TITLE
check-updates: fix version matching

### DIFF
--- a/install.vsh
+++ b/install.vsh
@@ -59,7 +59,7 @@ fn check_updates() ! {
 		return
 	}
 
-	if cur_version == asset.tag_name {
+	if cur_version.trim_string_left('v') == asset.tag_name.trim_string_left('v') {
 		println('You already have the latest version of ${term.bold('v-analyzer')}: ${cur_version}')
 		return
 	}
@@ -92,7 +92,7 @@ fn update(nightly bool) ! {
 	}
 	asset_version := asset.tag_name
 
-	if cur_version == asset_version {
+	if cur_version.trim_string_left('v') == asset.tag_name.trim_string_left('v') {
 		println('You already have the latest version of ${term.bold('v-analyzer')}: ${cur_version}')
 		return
 	}

--- a/install.vsh
+++ b/install.vsh
@@ -92,7 +92,7 @@ fn update(nightly bool) ! {
 	}
 	asset_version := asset.tag_name
 
-	if cur_version.trim_string_left('v') == asset.tag_name.trim_string_left('v') {
+	if cur_version.trim_string_left('v') == asset_version.trim_string_left('v') {
 		println('You already have the latest version of ${term.bold('v-analyzer')}: ${cur_version}')
 		return
 	}


### PR DESCRIPTION
This pr fixes/hardens the currently failing version matching between
- prefixed git tag beginning with `v`
- version constant inside the code without

`v0.0.1-beta.1` vs. `0.0.1-beta.1`