### PR TITLE
Fix multi-var assignment in tree_sitter_v

### DIFF
--- a/tree_sitter_v/grammar.js
+++ b/tree_sitter_v/grammar.js
@@ -12,6 +12,7 @@ const PREC = {
   resolve: 1,
   composite_literal: -1,
   empty_array: -2,
+  strictly_expression_list: -3,
 };
 
 const multiplicative_operators = ['*', '/', '%', '<<', '>>', '>>>', '&', '&^'];
@@ -455,7 +456,7 @@ module.exports = grammar({
       $.map_init_expression,
     ),
 
-    strictly_expression_list: ($) => prec(PREC.resolve, seq(
+    strictly_expression_list: ($) => prec(PREC.strictly_expression_list, seq(
       choice($._expression, $.mutable_expression), ',', comma_sep1(choice($._expression, $.mutable_expression)),
     )),
 

--- a/tree_sitter_v/src/grammar.json
+++ b/tree_sitter_v/src/grammar.json
@@ -2355,7 +2355,7 @@
     },
     "strictly_expression_list": {
       "type": "PREC",
-      "value": 1,
+      "value": -3,
       "content": {
         "type": "SEQ",
         "members": [

--- a/tree_sitter_v/test/corpus/var_declaration.txt
+++ b/tree_sitter_v/test/corpus/var_declaration.txt
@@ -17,7 +17,7 @@ foo := bar
 ================================================================================
 Several var declarations
 ================================================================================
-foo, goo := bar, zoo
+foo, goo, poo := bar, far, tar
 --------------------------------------------------------------------------------
 
 (source_file
@@ -27,8 +27,12 @@ foo, goo := bar, zoo
         (reference_expression
           (identifier))
         (reference_expression
+          (identifier))
+        (reference_expression
           (identifier)))
       (expression_list
+        (reference_expression
+          (identifier))
         (reference_expression
           (identifier))
         (reference_expression

--- a/tree_sitter_v/tools/project-checker.v
+++ b/tree_sitter_v/tools/project-checker.v
@@ -98,13 +98,14 @@ pub fn (mut i Checker) check() {
 	}
 
 	println('Checking finished')
-	println('Checking took ${time.since(now)}')
-	println('\nFound ${errors.len} errors in ${per_file.len} files')
-	println('\nParsed correctly ${(100 - (f64(per_file.len) / f64(processed_files) * 100))}% files out of ${processed_files}')
 
 	for error in errors[..50] {
 		println(error)
 	}
+
+	println('Checking took ${time.since(now)}')
+	println('\nFound ${errors.len} errors in ${per_file.len} files')
+	println('\nParsed correctly ${(100 - (f64(per_file.len) / f64(processed_files) * 100))}% files out of ${processed_files}')
 }
 
 pub fn (mut c Checker) check_file(path string) []ErrorInfo {


### PR DESCRIPTION
Currently `a, c, c = 1, 2, 3` fails with this error:

```
    (source_file
      (simple_statement
        (expression_list
          (reference_expression
            (identifier))
          (reference_expression
            (identifier))
          (reference_expression
            (identifier))))
      (ERROR)
      (simple_statement
        (expression_list
          (reference_expression
            (identifier))
          (reference_expression
            (identifier))
          (literal
            (int_literal)))))
```

This PR fixes it. And these are the final results of `v run tree_sitter_v/tools/project-checker.v`

| main | fix-multi-vars |
|--------|--------|
| Found 6908 errors in 307 files  |  Found 6799 errors in 265 files |
Parsed correctly 88.16955684007706% files out of 2595  | Parsed correctly 89.78805394990366% files out of 2595 |