### PR TITLE
refactor: simplify `build.vsh`

### DIFF
--- a/build.vsh
+++ b/build.vsh
@@ -54,7 +54,7 @@ fn dev() os.Result {
 }
 
 fn release() os.Result {
-	return os.execute('${base_build_command} ${compiler_flag} -w -cflags "-O3 -DNDEBUG" -prod')
+	return os.execute('${base_build_command} ${compiler_flag} -w -cflags -prod')
 }
 
 fn prepare_output_dir() {

--- a/build.vsh
+++ b/build.vsh
@@ -43,25 +43,16 @@ fn errorln(msg string) {
 	eprintln('${term.red('[ERROR]')} ${msg}')
 }
 
-// debug builds the v-analyzer binary in debug mode.
-// This is the default mode.
-// Thanks to -d use_libbacktrace, the binary will print beautiful stack traces,
-// which is very useful for debugging.
 fn debug() os.Result {
 	libbacktrace := $if windows { '' } $else { '-d use_libbacktrace' }
 	return os.execute('${base_build_command} ${compiler_flag} -g ${libbacktrace}')
 }
 
-// dev builds the v-analyzer binary in development mode.
-// In this mode, additional development features are enabled.
 fn dev() os.Result {
 	libbacktrace := $if windows { '' } $else { '-d use_libbacktrace' }
 	return os.execute('${base_build_command} ${compiler_flag} -d show_ast_on_hover -g ${libbacktrace}')
 }
 
-// release builds the v-analyzer binary in release mode.
-// This is the recommended mode for production use.
-// It is about 30-40% faster than debug mode.
 fn release() os.Result {
 	return os.execute('${base_build_command} ${compiler_flag} -w -cflags "-O3 -DNDEBUG" -prod')
 }
@@ -112,6 +103,10 @@ mut cmd := cli.Command{
 	}
 }
 
+// debug builds the v-analyzer binary in debug mode.
+// This is the default mode.
+// Thanks to -d use_libbacktrace, the binary will print beautiful stack traces,
+// which is very useful for debugging.
 cmd.add_command(cli.Command{
 	name: 'debug'
 	description: 'Builds the v-analyzer binary in debug mode.'
@@ -120,6 +115,8 @@ cmd.add_command(cli.Command{
 	}
 })
 
+// dev builds the v-analyzer binary in development mode.
+// In this mode, additional development features are enabled.
 cmd.add_command(cli.Command{
 	name: 'dev'
 	description: 'Builds the v-analyzer binary in development mode.'
@@ -128,6 +125,9 @@ cmd.add_command(cli.Command{
 	}
 })
 
+// release builds the v-analyzer binary in release mode.
+// This is the recommended mode for production use.
+// It is about 30-40% faster than debug mode.
 cmd.add_command(cli.Command{
 	name: 'release'
 	description: 'Builds the v-analyzer binary in release mode.'

--- a/build.vsh
+++ b/build.vsh
@@ -71,8 +71,7 @@ fn build(mode ReleaseMode, explicit_debug bool) {
 	println('${term.green('✓')} Prepared output directory')
 
 	cmd := mode.cmd()
-	cmd_name := mode.str()
-	println('Building v-analyzer in ${term.bold(cmd_name)} mode...')
+	println('Building v-analyzer in ${term.bold(mode.str())} mode...')
 	if mode == .release {
 		println('This may take a while...')
 	}

--- a/build.vsh
+++ b/build.vsh
@@ -38,7 +38,7 @@ fn errorln(msg string) {
 fn (m ReleaseMode) compile() os.Result {
 	libbacktrace := $if windows { '' } $else { '-d use_libbacktrace' }
 	return match m {
-		.release { os.execute('${base_build_command} ${compiler_flag} -w -cflags -prod') }
+		.release { os.execute('${base_build_command} ${compiler_flag} -w -prod') }
 		.debug { os.execute('${base_build_command} ${compiler_flag} -g ${libbacktrace}') }
 		.dev { os.execute('${base_build_command} ${compiler_flag} -d show_ast_on_hover -g ${libbacktrace}') }
 	}

--- a/build.vsh
+++ b/build.vsh
@@ -70,7 +70,6 @@ fn build(mode ReleaseMode, explicit_debug bool) {
 	prepare_output_dir()
 	println('${term.green('✓')} Prepared output directory')
 
-	cmd := mode.cmd()
 	println('Building v-analyzer in ${term.bold(mode.str())} mode...')
 	if mode == .release {
 		println('This may take a while...')
@@ -81,6 +80,7 @@ fn build(mode ReleaseMode, explicit_debug bool) {
 		println('Release mode is recommended for production use. It is about 30-40% faster than debug mode.')
 	}
 
+	cmd := mode.cmd()
 	res := cmd()
 	if res.exit_code != 0 {
 		errorln('Failed to build v-analyzer')


### PR DESCRIPTION
Thanks again for the good review @spytheman. This splits up the PR. First the simplification. 
**This is mainly to make the mode available for the compile command.** Then adding a compiler that is meant for prod builds on linux is a simple change in a followup. 

I also tried to split this PR into commits that are hopefully easy to follow.