### PR TITLE
refactor: simplify keeping version consistent with v-analyzer metadata, format comptime ternary exp

### DIFF
--- a/build.vsh
+++ b/build.vsh
@@ -12,11 +12,7 @@ import term
 
 pub const (
 	code_path          = './cmd/v-analyzer'
-	bin_path           = './bin/v-analyzer' + $if windows {
-		'.exe'
-	} $else {
-		''
-	}
+	bin_path           = './bin/v-analyzer' + $if windows { '.exe' } $else { '' }
 	base_build_command = '${@VEXE} ${code_path} -o ${bin_path}'
 )
 

--- a/build.vsh
+++ b/build.vsh
@@ -9,8 +9,10 @@
 import os
 import cli
 import term
+import v.vmod
 
 pub const (
+	version            = vmod.decode(@VMOD_FILE) or { panic(err) }.version
 	code_path          = './cmd/v-analyzer'
 	bin_path           = './bin/v-analyzer' + $if windows { '.exe' } $else { '' }
 	base_build_command = '${@VEXE} ${code_path} -o ${bin_path}'
@@ -81,7 +83,7 @@ fn build(mode ReleaseMode, explicit_debug bool) {
 
 mut cmd := cli.Command{
 	name: 'v-analyzer-builder'
-	version: '0.0.1-beta.1'
+	version: version
 	description: 'Builds the v-analyzer binary.'
 	posix_mode: true
 	execute: fn (_ cli.Command) ! {

--- a/cmd/v-analyzer/main.v
+++ b/cmd/v-analyzer/main.v
@@ -11,11 +11,9 @@ import jsonrpc
 import streams
 import analyzer
 import lsp.log
+import v.vmod
 
-// version is the current version of the analyzer.
-// When you release a new version, make sure to update this constant and
-// and any other places that need to be updated (use search across the project).
-const version = '0.0.1-beta.1'
+const manifest = vmod.decode(@VMOD_FILE) or { panic(err) }
 
 // default_tcp_port is default TCP port that the analyzer uses to connect to the socket
 // when the --socket flag is passed at startup.
@@ -90,9 +88,9 @@ fn setup_logger(to_file bool) {
 
 fn main() {
 	mut cmd := cli.Command{
-		name: 'v-analyzer'
-		version: version
-		description: 'Language server implementation for V language'
+		name: manifest.name
+		version: manifest.version
+		description: manifest.description
 		execute: run
 		posix_mode: true
 	}
@@ -128,7 +126,7 @@ fn main() {
 		description: 'Checks for v-analyzer updates.'
 		execute: check_updates_cmd
 		posix_mode: true
-		version: version
+		version: manifest.version
 	})
 
 	cmd.add_flags([

--- a/install.vsh
+++ b/install.vsh
@@ -8,8 +8,10 @@ import time
 import szip
 import cli
 import net.http
+import v.vmod
 
 pub const (
+	version                     = vmod.decode(@VMOD_FILE) or { panic(err) }.version
 	analyzer_sources_path       = norm_expand_tilde_to_home('~/.config/v-analyzer/sources')
 	analyzer_bin_path           = norm_expand_tilde_to_home('~/.config/v-analyzer/bin')
 	analyzer_bin_path_with_name = norm_expand_tilde_to_home('~/.config/v-analyzer/bin/v-analyzer')
@@ -467,7 +469,7 @@ pub fn warnln(msg string) {
 
 mut cmd := cli.Command{
 	name: 'v-analyzer-installer-updated'
-	version: '0.0.1-beta.1'
+	version: version
 	description: 'Install and update v-analyzer'
 	posix_mode: true
 	execute: fn (cmd cli.Command) ! {

--- a/server/general.v
+++ b/server/general.v
@@ -14,6 +14,9 @@ import server.protocol
 import server.semantic
 import server.progress
 import server.intentions
+import v.vmod
+
+const manifest = vmod.decode(@VMOD_FILE) or { panic(err) }
 
 // initialize sends the server capabilities to the client
 pub fn (mut ls LanguageServer) initialize(params lsp.InitializeParams, mut wr ResponseWriter) lsp.InitializeResult {
@@ -86,8 +89,8 @@ pub fn (mut ls LanguageServer) initialize(params lsp.InitializeParams, mut wr Re
 			}
 		}
 		server_info: lsp.ServerInfo{
-			name: 'v-analyzer'
-			version: '0.0.1-beta.1'
+			name: server.manifest.name
+			version: server.manifest.version
 		}
 	}
 }
@@ -416,7 +419,7 @@ fn (mut ls LanguageServer) print_info(process_id int, client_info lsp.ClientInfo
 		'Unknown'
 	}
 
-	ls.client.log_message('v-analyzer version: 0.0.1-beta.1, OS: ${os.user_os()} x${arch}',
+	ls.client.log_message('v-analyzer version: ${server.manifest.version}, OS: ${os.user_os()} x${arch}',
 		.info)
 	ls.client.log_message('v-analyzer executable path: ${os.executable()}', .info)
 	ls.client.log_message('v-analyzer build with V ${@VHASH}', .info)


### PR DESCRIPTION
- This will help to keep consistency without manual changes in case of version bumps. 
- Adds a little formatting change in `build.vsh` that is supported by v fmt since recent changes.

In case the version in `build.vsh` and `install.vsh` should always match the version of the v-analyzer binary, the change should be extended to those files as well.
https://github.com/v-analyzer/v-analyzer/blob/975f34bec1dfad391534c83a6df019c0c200887a/build.vsh#L86-L88