### PR TITLE
fix: NO_RESULT_CALLBACK_FOUND in neovim

### DIFF
--- a/server/features_hover.v
+++ b/server/features_hover.v
@@ -5,9 +5,10 @@ import server.documentation
 import loglib
 import server.tform
 
-pub fn (mut ls LanguageServer) hover(params lsp.HoverParams) ?lsp.Hover {
+pub fn (mut ls LanguageServer) hover(params lsp.HoverParams) lsp.Hover {
+	empty_hover := lsp.Hover{}
 	uri := params.text_document.uri.normalize()
-	file := ls.get_file(uri)?
+	file := ls.get_file(uri) or { return empty_hover }
 
 	loglib.with_fields({
 		'position': params.position.str()
@@ -19,7 +20,7 @@ pub fn (mut ls LanguageServer) hover(params lsp.HoverParams) ?lsp.Hover {
 		loglib.with_fields({
 			'offset': offset.str()
 		}).warn('Cannot find element')
-		return none
+		return empty_hover
 	}
 
 	if element.element_type() == .unknown {
@@ -33,7 +34,7 @@ pub fn (mut ls LanguageServer) hover(params lsp.HoverParams) ?lsp.Hover {
 	}
 
 	mut provider := documentation.Provider{}
-	doc_element := provider.find_documentation_element(element)?
+	doc_element := provider.find_documentation_element(element) or { return empty_hover }
 	if content := provider.documentation(doc_element) {
 		return lsp.Hover{
 			contents: lsp.hover_markdown_string(content)
@@ -62,5 +63,5 @@ pub fn (mut ls LanguageServer) hover(params lsp.HoverParams) ?lsp.Hover {
 		}
 	}
 
-	return none
+	return empty_hover
 }

--- a/server/features_implementation.v
+++ b/server/features_implementation.v
@@ -6,16 +6,17 @@ import server.tform
 import analyzer.psi
 import analyzer.psi.search
 
-pub fn (mut ls LanguageServer) implementation(params lsp.TextDocumentPositionParams) ?[]lsp.Location {
+pub fn (mut ls LanguageServer) implementation(params lsp.TextDocumentPositionParams) []lsp.Location {
+	empty_location := []lsp.Location{}
 	uri := params.text_document.uri.normalize()
-	file := ls.get_file(uri)?
+	file := ls.get_file(uri) or { return empty_location }
 
 	offset := file.find_offset(params.position)
 	element := file.psi_file.find_element_at(offset) or {
 		loglib.with_fields({
 			'offset': offset.str()
 		}).warn('Cannot find element')
-		return none
+		return empty_location
 	}
 
 	if method := element.parent_of_type(.interface_method_definition) {
@@ -52,5 +53,5 @@ pub fn (mut ls LanguageServer) implementation(params lsp.TextDocumentPositionPar
 		'element_type': element.element_type().str()
 	}).warn('Element is not inside an interface or struct declaration')
 
-	return none
+	return empty_location
 }

--- a/server/features_inlay_hints.v
+++ b/server/features_inlay_hints.v
@@ -3,13 +3,14 @@ module server
 import lsp
 import server.hints
 
-pub fn (mut ls LanguageServer) inlay_hints(params lsp.InlayHintParams) ?[]lsp.InlayHint {
+pub fn (mut ls LanguageServer) inlay_hints(params lsp.InlayHintParams) []lsp.InlayHint {
+	empty_hint := []lsp.InlayHint{}
 	if !ls.cfg.inlay_hints.enable {
-		return none
+		return empty_hint
 	}
 
 	uri := params.text_document.uri.normalize()
-	file := ls.get_file(uri)?
+	file := ls.get_file(uri) or { return empty_hint }
 
 	mut visitor := hints.InlayHintsVisitor{
 		cfg: ls.cfg.inlay_hints

--- a/server/features_semantic_tokens.v
+++ b/server/features_semantic_tokens.v
@@ -4,18 +4,16 @@ import lsp
 import server.semantic
 import time
 
-const (
-	max_line_for_resolve_semantic_tokens = 1000
-	max_line_for_any_semantic_tokens     = 10000
-)
+const max_line_for_resolve_semantic_tokens = 1000
+const max_line_for_any_semantic_tokens = 10000
 
-pub fn (mut ls LanguageServer) semantic_tokens(text_document lsp.TextDocumentIdentifier, range lsp.Range) ?lsp.SemanticTokens {
+pub fn (mut ls LanguageServer) semantic_tokens(text_document lsp.TextDocumentIdentifier, range lsp.Range) lsp.SemanticTokens {
 	if ls.cfg.enable_semantic_tokens == .none_ {
-		return none
+		return lsp.SemanticTokens{}
 	}
 
 	uri := text_document.uri.normalize()
-	file := ls.get_file(uri)?
+	file := ls.get_file(uri) or { return lsp.SemanticTokens{} }
 
 	lines := file.psi_file.source_text.count('\n')
 

--- a/server/features_signature_help.v
+++ b/server/features_signature_help.v
@@ -4,23 +4,24 @@ import lsp
 import analyzer.psi
 import loglib
 
-pub fn (mut ls LanguageServer) signature_help(params lsp.SignatureHelpParams) ?lsp.SignatureHelp {
+pub fn (mut ls LanguageServer) signature_help(params lsp.SignatureHelpParams) lsp.SignatureHelp {
+	mut help := lsp.SignatureHelp{}
 	uri := params.text_document.uri.normalize()
-	file := ls.get_file(uri)?
+	file := ls.get_file(uri) or { return help }
 
 	offset := file.find_offset(params.position)
 	element := file.psi_file.find_element_at(offset) or {
 		loglib.with_fields({
 			'offset': offset.str()
 		}).warn('Cannot find element')
-		return lsp.SignatureHelp{}
+		return help
 	}
 
 	call := element.parent_of_type_or_self(.call_expression) or {
 		loglib.with_fields({
 			'offset': offset.str()
 		}).warn('Cannot find call expression')
-		return lsp.SignatureHelp{}
+		return help
 	}
 
 	if call is psi.CallExpression {
@@ -28,7 +29,7 @@ pub fn (mut ls LanguageServer) signature_help(params lsp.SignatureHelpParams) ?l
 			loglib.with_fields({
 				'offset': offset.str()
 			}).warn('Cannot resolve call expression for signature help')
-			return lsp.SignatureHelp{}
+			return help
 		}
 
 		if resolved is psi.FunctionOrMethodDeclaration {
@@ -36,12 +37,12 @@ pub fn (mut ls LanguageServer) signature_help(params lsp.SignatureHelpParams) ?l
 			active_parameter := call.parameter_index_on_offset(offset)
 
 			if ctx.is_retrigger {
-				mut help := ctx.active_signature_help
+				help = ctx.active_signature_help
 				help.active_parameter = active_parameter
 				return help
 			}
 
-			signature := resolved.signature()?
+			signature := resolved.signature() or { return help }
 			parameters := signature.parameters()
 
 			mut param_infos := []lsp.ParameterInformation{}
@@ -63,5 +64,5 @@ pub fn (mut ls LanguageServer) signature_help(params lsp.SignatureHelpParams) ?l
 		}
 	}
 
-	return lsp.SignatureHelp{}
+	return help
 }

--- a/server/features_signature_help.v
+++ b/server/features_signature_help.v
@@ -13,14 +13,14 @@ pub fn (mut ls LanguageServer) signature_help(params lsp.SignatureHelpParams) ?l
 		loglib.with_fields({
 			'offset': offset.str()
 		}).warn('Cannot find element')
-		return none
+		return lsp.SignatureHelp{}
 	}
 
 	call := element.parent_of_type_or_self(.call_expression) or {
 		loglib.with_fields({
 			'offset': offset.str()
 		}).warn('Cannot find call expression')
-		return none
+		return lsp.SignatureHelp{}
 	}
 
 	if call is psi.CallExpression {
@@ -28,7 +28,7 @@ pub fn (mut ls LanguageServer) signature_help(params lsp.SignatureHelpParams) ?l
 			loglib.with_fields({
 				'offset': offset.str()
 			}).warn('Cannot resolve call expression for signature help')
-			return none
+			return lsp.SignatureHelp{}
 		}
 
 		if resolved is psi.FunctionOrMethodDeclaration {
@@ -63,5 +63,5 @@ pub fn (mut ls LanguageServer) signature_help(params lsp.SignatureHelpParams) ?l
 		}
 	}
 
-	return none
+	return lsp.SignatureHelp{}
 }

--- a/server/features_type_definition.v
+++ b/server/features_type_definition.v
@@ -5,16 +5,17 @@ import analyzer.psi
 import analyzer.psi.types
 import loglib
 
-pub fn (mut ls LanguageServer) type_definition(params lsp.TextDocumentPositionParams) ?[]lsp.LocationLink {
+pub fn (mut ls LanguageServer) type_definition(params lsp.TextDocumentPositionParams) []lsp.LocationLink {
+	empty_loc_link := []lsp.LocationLink{}
 	uri := params.text_document.uri.normalize()
-	file := ls.get_file(uri)?
+	file := ls.get_file(uri) or { return empty_loc_link }
 
 	offset := file.find_offset(params.position)
 	element := file.psi_file.find_reference_at(offset) or {
 		loglib.with_fields({
 			'offset': offset.str()
 		}).warn('Cannot find reference')
-		return none
+		return empty_loc_link
 	}
 
 	element_text_range := element.text_range()
@@ -24,11 +25,11 @@ pub fn (mut ls LanguageServer) type_definition(params lsp.TextDocumentPositionPa
 			'caller': @METHOD
 			'name':   element.name()
 		}).warn('Cannot resolve reference')
-		return none
+		return empty_loc_link
 	}
 
 	typ := types.unwrap_generic_instantiation_type(types.unwrap_pointer_type(psi.infer_type(resolved)))
-	type_element := psi.find_element(typ.qualified_name())?
+	type_element := psi.find_element(typ.qualified_name()) or { return empty_loc_link }
 
 	data := new_resolve_result(type_element.containing_file(), type_element) or { return [] }
 	return [

--- a/server/language_server.v
+++ b/server/language_server.v
@@ -198,7 +198,7 @@ pub fn (mut ls LanguageServer) handle_jsonrpc(request &jsonrpc.Request, mut rw j
 				params := json.decode(lsp.DocumentSymbolParams, request.params) or {
 					return w.wrap_error(err)
 				}
-				w.write(ls.document_symbol(params) or { return w.wrap_error(err) })
+				w.write(ls.document_symbol(params))
 			}
 			'workspace/symbol' {
 				params := json.decode(lsp.WorkspaceSymbolParams, request.params) or {
@@ -210,7 +210,7 @@ pub fn (mut ls LanguageServer) handle_jsonrpc(request &jsonrpc.Request, mut rw j
 				params := json.decode(lsp.SignatureHelpParams, request.params) or {
 					return w.wrap_error(err)
 				}
-				w.write(ls.signature_help(params) or { return w.wrap_error(err) })
+				w.write(ls.signature_help(params))
 			}
 			'textDocument/completion' {
 				params := json.decode(lsp.CompletionParams, request.params) or {
@@ -222,11 +222,7 @@ pub fn (mut ls LanguageServer) handle_jsonrpc(request &jsonrpc.Request, mut rw j
 				params := json.decode(lsp.HoverParams, request.params) or {
 					return w.wrap_error(err)
 				}
-				hover_data := ls.hover(params) or {
-					w.write_empty()
-					return
-				}
-				w.write(hover_data)
+				w.write(ls.hover(params))
 			}
 			'textDocument/foldingRange' {
 				params := json.decode(lsp.FoldingRangeParams, request.params) or {
@@ -238,13 +234,13 @@ pub fn (mut ls LanguageServer) handle_jsonrpc(request &jsonrpc.Request, mut rw j
 				params := json.decode(lsp.TextDocumentPositionParams, request.params) or {
 					return w.wrap_error(err)
 				}
-				w.write(ls.definition(params) or { return w.wrap_error(err) })
+				w.write(ls.definition(params))
 			}
 			'textDocument/typeDefinition' {
 				params := json.decode(lsp.TextDocumentPositionParams, request.params) or {
 					return w.wrap_error(err)
 				}
-				w.write(ls.type_definition(params) or { return w.wrap_error(err) })
+				w.write(ls.type_definition(params))
 			}
 			'textDocument/references' {
 				params := json.decode(lsp.ReferenceParams, request.params) or {
@@ -256,7 +252,7 @@ pub fn (mut ls LanguageServer) handle_jsonrpc(request &jsonrpc.Request, mut rw j
 				params := json.decode(lsp.TextDocumentPositionParams, request.params) or {
 					return w.wrap_error(err)
 				}
-				w.write(ls.implementation(params) or { return w.wrap_error(err) })
+				w.write(ls.implementation(params))
 			}
 			'workspace/didChangeWatchedFiles' {
 				params := json.decode(lsp.DidChangeWatchedFilesParams, request.params) or {
@@ -274,7 +270,7 @@ pub fn (mut ls LanguageServer) handle_jsonrpc(request &jsonrpc.Request, mut rw j
 				params := json.decode(lsp.InlayHintParams, request.params) or {
 					return w.wrap_error(err)
 				}
-				w.write(ls.inlay_hints(params) or { return w.wrap_error(err) })
+				w.write(ls.inlay_hints(params))
 			}
 			'textDocument/prepareRename' {
 				params := json.decode(lsp.PrepareRenameParams, request.params) or {
@@ -293,17 +289,13 @@ pub fn (mut ls LanguageServer) handle_jsonrpc(request &jsonrpc.Request, mut rw j
 				params := json.decode(lsp.SemanticTokensParams, request.params) or {
 					return w.wrap_error(err)
 				}
-				w.write(ls.semantic_tokens(params.text_document, lsp.Range{}) or {
-					return w.wrap_error(err)
-				})
+				w.write(ls.semantic_tokens(params.text_document, lsp.Range{}))
 			}
 			'textDocument/semanticTokens/range' {
 				params := json.decode(lsp.SemanticTokensRangeParams, request.params) or {
 					return w.wrap_error(err)
 				}
-				w.write(ls.semantic_tokens(params.text_document, params.range) or {
-					return w.wrap_error(err)
-				})
+				w.write(ls.semantic_tokens(params.text_document, params.range))
 			}
 			'textDocument/documentHighlight' {
 				params := json.decode(lsp.TextDocumentPositionParams, request.params) or {


### PR DESCRIPTION
The spec says "Every processed request must send a response back to the sender of the request." The Signature Help response was returning null (which the spec also says is okay, but neovim does not accept this).

So return an empty struct instead.

closes #9

NOTE: this PR is only tested in Neovim