### PR TITLE
ci: update nightly_release.yml

### DIFF
--- a/.github/workflows/analyzer_tests.yml
+++ b/.github/workflows/analyzer_tests.yml
@@ -2,7 +2,11 @@ name: Analyzer tests
 
 on:
   push:
+    paths-ignore:
+      - '**/*.md'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   test:

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -2,7 +2,11 @@ name: Build CI
 
 on:
   push:
+    paths-ignore:
+      - '**/*.md'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   test:

--- a/.github/workflows/install_ci.yml
+++ b/.github/workflows/install_ci.yml
@@ -2,7 +2,11 @@ name: Install CI
 
 on:
   push:
+    paths-ignore:
+      - '**/*.md'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   test:

--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -86,6 +86,7 @@ jobs:
 
   nightly-release:
     name: Create Nightly GitHub Release
+    if: github.event.repository.full_name == 'v-analyzer/v-analyzer'
     needs: dist
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
 
 permissions:
   contents: write
@@ -34,7 +36,7 @@ jobs:
 
     steps:
       - uses: msys2/setup-msys2@v2
-        if: matrix.os == 'windows-latest'
+        if: runner.os == 'Windows'
 
       - name: Install V
         id: install-v
@@ -54,7 +56,7 @@ jobs:
           cd v-analyzer
           v install
           v -d cross_compile_macos_arm64 build.vsh release
-      
+
       - name: Compile
         if: matrix.target != 'darwin-arm64'
         run: |
@@ -84,7 +86,7 @@ jobs:
 
   nightly-release:
     name: Create Nightly GitHub Release
-    needs: [ dist ]
+    needs: dist
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
@@ -108,14 +110,14 @@ jobs:
         with:
           name: v-analyzer-windows-x86_64.zip
           path: ./
-      - uses: "marvinpinto/action-automatic-releases@latest"
+      - uses: marvinpinto/action-automatic-releases@latest
         name: Create Release and Upload Assets
         id: create_release
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "latest"
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          automatic_release_tag: latest
           prerelease: true
-          title: "nightly release"
+          title: nightly release
           files: |
             v-analyzer-linux-x86_64.zip
             v-analyzer-darwin-x86_64.zip


### PR DESCRIPTION
Changes:
- limit CI to relevant paths, e.g., don't make releases of only `.md` files are changed
- don't make releases on forks when there are pushes to main
- update syntax in `nightly_release.yml`

For further changes:
Personally I prefer if nightly releases are "silent" - that not every nightly release, on every push, appears in a github feed.

This is how e.g. [kitty](https://github.com/kovidgoyal/kitty/releases) is doing it. Here there is one nightly tag that is updated but it won't create an announcement when it is updated.
I integrated it that way some time ago into [webui](https://github.com/webui-dev/webui/releases)

If that's also something for v-analyzer, please let me know.