### PR TITLE
fix: remove redundant write, improve language server method handling

### DIFF
--- a/server/ResponseWriter.v
+++ b/server/ResponseWriter.v
@@ -7,7 +7,6 @@ pub type ResponseWriter = jsonrpc.ResponseWriter
 
 fn (mut wr ResponseWriter) wrap_error(err IError) IError {
 	if err is none {
-		wr.write(jsonrpc.null)
 		return err
 	}
 	wr.log_message(err.msg(), .error)

--- a/server/features_document_symbol.v
+++ b/server/features_document_symbol.v
@@ -4,24 +4,23 @@ import lsp
 import analyzer.psi
 import server.tform
 
-pub fn (mut ls LanguageServer) document_symbol(params lsp.DocumentSymbolParams) []lsp.DocumentSymbol {
+pub fn (mut ls LanguageServer) document_symbol(params lsp.DocumentSymbolParams) ![]lsp.DocumentSymbol {
 	uri := params.text_document.uri.normalize()
 	mut file_symbols := []lsp.DocumentSymbol{}
 
 	elements := stubs_index.get_all_elements_from_file(uri.path())
 	for element in elements {
-		file_symbols << document_symbol_presentation(element)
+		file_symbols << document_symbol_presentation(element) or { continue }
 	}
 
 	return file_symbols
 }
 
-fn document_symbol_presentation(element psi.PsiElement) lsp.DocumentSymbol {
-	empty_doc_symbol := lsp.DocumentSymbol{}
+fn document_symbol_presentation(element psi.PsiElement) ?lsp.DocumentSymbol {
 	full_text_range := element.text_range()
 	if element is psi.PsiNamedElement {
 		if element.name() == '' {
-			return empty_doc_symbol
+			return none
 		}
 
 		identifier_text_range := element.identifier_text_range()
@@ -29,14 +28,14 @@ fn document_symbol_presentation(element psi.PsiElement) lsp.DocumentSymbol {
 		return lsp.DocumentSymbol{
 			name: name_presentation(element)
 			detail: detail_presentation(element)
-			kind: symbol_kind(element as psi.PsiElement) or { return empty_doc_symbol }
+			kind: symbol_kind(element as psi.PsiElement)?
 			range: tform.text_range_to_lsp_range(full_text_range)
 			selection_range: tform.text_range_to_lsp_range(identifier_text_range)
 			children: children
 		}
 	}
 
-	return empty_doc_symbol
+	return none
 }
 
 fn symbol_kind(element psi.PsiElement) ?lsp.SymbolKind {
@@ -137,7 +136,7 @@ fn symbol_children(element psi.PsiNamedElement) []lsp.DocumentSymbol {
 
 	mut symbols := []lsp.DocumentSymbol{cap: children.len}
 	for child in children {
-		symbols << document_symbol_presentation(child)
+		symbols << document_symbol_presentation(child) or { continue }
 	}
 	return symbols
 }

--- a/server/features_hover.v
+++ b/server/features_hover.v
@@ -5,10 +5,9 @@ import server.documentation
 import loglib
 import server.tform
 
-pub fn (mut ls LanguageServer) hover(params lsp.HoverParams) lsp.Hover {
-	empty_hover := lsp.Hover{}
+pub fn (mut ls LanguageServer) hover(params lsp.HoverParams) ?lsp.Hover {
 	uri := params.text_document.uri.normalize()
-	file := ls.get_file(uri) or { return empty_hover }
+	file := ls.get_file(uri)?
 
 	loglib.with_fields({
 		'position': params.position.str()
@@ -20,7 +19,7 @@ pub fn (mut ls LanguageServer) hover(params lsp.HoverParams) lsp.Hover {
 		loglib.with_fields({
 			'offset': offset.str()
 		}).warn('Cannot find element')
-		return empty_hover
+		return none
 	}
 
 	if element.element_type() == .unknown {
@@ -34,7 +33,7 @@ pub fn (mut ls LanguageServer) hover(params lsp.HoverParams) lsp.Hover {
 	}
 
 	mut provider := documentation.Provider{}
-	doc_element := provider.find_documentation_element(element) or { return empty_hover }
+	doc_element := provider.find_documentation_element(element)?
 	if content := provider.documentation(doc_element) {
 		return lsp.Hover{
 			contents: lsp.hover_markdown_string(content)
@@ -63,5 +62,5 @@ pub fn (mut ls LanguageServer) hover(params lsp.HoverParams) lsp.Hover {
 		}
 	}
 
-	return empty_hover
+	return none
 }

--- a/server/features_implementation.v
+++ b/server/features_implementation.v
@@ -6,17 +6,16 @@ import server.tform
 import analyzer.psi
 import analyzer.psi.search
 
-pub fn (mut ls LanguageServer) implementation(params lsp.TextDocumentPositionParams) []lsp.Location {
-	empty_location := []lsp.Location{}
+pub fn (mut ls LanguageServer) implementation(params lsp.TextDocumentPositionParams) ?[]lsp.Location {
 	uri := params.text_document.uri.normalize()
-	file := ls.get_file(uri) or { return empty_location }
+	file := ls.get_file(uri)?
 
 	offset := file.find_offset(params.position)
 	element := file.psi_file.find_element_at(offset) or {
 		loglib.with_fields({
 			'offset': offset.str()
 		}).warn('Cannot find element')
-		return empty_location
+		return none
 	}
 
 	if method := element.parent_of_type(.interface_method_definition) {
@@ -53,5 +52,5 @@ pub fn (mut ls LanguageServer) implementation(params lsp.TextDocumentPositionPar
 		'element_type': element.element_type().str()
 	}).warn('Element is not inside an interface or struct declaration')
 
-	return empty_location
+	return none
 }

--- a/server/features_inlay_hints.v
+++ b/server/features_inlay_hints.v
@@ -3,14 +3,13 @@ module server
 import lsp
 import server.hints
 
-pub fn (mut ls LanguageServer) inlay_hints(params lsp.InlayHintParams) []lsp.InlayHint {
-	empty_hint := []lsp.InlayHint{}
+pub fn (mut ls LanguageServer) inlay_hints(params lsp.InlayHintParams) ?[]lsp.InlayHint {
 	if !ls.cfg.inlay_hints.enable {
-		return empty_hint
+		return none
 	}
 
 	uri := params.text_document.uri.normalize()
-	file := ls.get_file(uri) or { return empty_hint }
+	file := ls.get_file(uri)?
 
 	mut visitor := hints.InlayHintsVisitor{
 		cfg: ls.cfg.inlay_hints

--- a/server/features_semantic_tokens.v
+++ b/server/features_semantic_tokens.v
@@ -4,16 +4,18 @@ import lsp
 import server.semantic
 import time
 
-const max_line_for_resolve_semantic_tokens = 1000
-const max_line_for_any_semantic_tokens = 10000
+const (
+	max_line_for_resolve_semantic_tokens = 1000
+	max_line_for_any_semantic_tokens     = 10000
+)
 
-pub fn (mut ls LanguageServer) semantic_tokens(text_document lsp.TextDocumentIdentifier, range lsp.Range) lsp.SemanticTokens {
+pub fn (mut ls LanguageServer) semantic_tokens(text_document lsp.TextDocumentIdentifier, range lsp.Range) ?lsp.SemanticTokens {
 	if ls.cfg.enable_semantic_tokens == .none_ {
-		return lsp.SemanticTokens{}
+		return none
 	}
 
 	uri := text_document.uri.normalize()
-	file := ls.get_file(uri) or { return lsp.SemanticTokens{} }
+	file := ls.get_file(uri)?
 
 	lines := file.psi_file.source_text.count('\n')
 

--- a/server/features_type_definition.v
+++ b/server/features_type_definition.v
@@ -5,17 +5,16 @@ import analyzer.psi
 import analyzer.psi.types
 import loglib
 
-pub fn (mut ls LanguageServer) type_definition(params lsp.TextDocumentPositionParams) []lsp.LocationLink {
-	empty_loc_link := []lsp.LocationLink{}
+pub fn (mut ls LanguageServer) type_definition(params lsp.TextDocumentPositionParams) ?[]lsp.LocationLink {
 	uri := params.text_document.uri.normalize()
-	file := ls.get_file(uri) or { return empty_loc_link }
+	file := ls.get_file(uri)?
 
 	offset := file.find_offset(params.position)
 	element := file.psi_file.find_reference_at(offset) or {
 		loglib.with_fields({
 			'offset': offset.str()
 		}).warn('Cannot find reference')
-		return empty_loc_link
+		return none
 	}
 
 	element_text_range := element.text_range()
@@ -25,11 +24,11 @@ pub fn (mut ls LanguageServer) type_definition(params lsp.TextDocumentPositionPa
 			'caller': @METHOD
 			'name':   element.name()
 		}).warn('Cannot resolve reference')
-		return empty_loc_link
+		return none
 	}
 
 	typ := types.unwrap_generic_instantiation_type(types.unwrap_pointer_type(psi.infer_type(resolved)))
-	type_element := psi.find_element(typ.qualified_name()) or { return empty_loc_link }
+	type_element := psi.find_element(typ.qualified_name())?
 
 	data := new_resolve_result(type_element.containing_file(), type_element) or { return [] }
 	return [

--- a/server/language_server.v
+++ b/server/language_server.v
@@ -198,7 +198,7 @@ pub fn (mut ls LanguageServer) handle_jsonrpc(request &jsonrpc.Request, mut rw j
 				params := json.decode(lsp.DocumentSymbolParams, request.params) or {
 					return w.wrap_error(err)
 				}
-				w.write(ls.document_symbol(params))
+				w.write(ls.document_symbol(params) or { return w.wrap_error(err) })
 			}
 			'workspace/symbol' {
 				params := json.decode(lsp.WorkspaceSymbolParams, request.params) or {
@@ -210,7 +210,7 @@ pub fn (mut ls LanguageServer) handle_jsonrpc(request &jsonrpc.Request, mut rw j
 				params := json.decode(lsp.SignatureHelpParams, request.params) or {
 					return w.wrap_error(err)
 				}
-				w.write(ls.signature_help(params))
+				w.write(ls.signature_help(params) or { return w.wrap_error(err) })
 			}
 			'textDocument/completion' {
 				params := json.decode(lsp.CompletionParams, request.params) or {
@@ -222,7 +222,11 @@ pub fn (mut ls LanguageServer) handle_jsonrpc(request &jsonrpc.Request, mut rw j
 				params := json.decode(lsp.HoverParams, request.params) or {
 					return w.wrap_error(err)
 				}
-				w.write(ls.hover(params))
+				hover_data := ls.hover(params) or {
+					w.write_empty()
+					return
+				}
+				w.write(hover_data)
 			}
 			'textDocument/foldingRange' {
 				params := json.decode(lsp.FoldingRangeParams, request.params) or {
@@ -234,13 +238,13 @@ pub fn (mut ls LanguageServer) handle_jsonrpc(request &jsonrpc.Request, mut rw j
 				params := json.decode(lsp.TextDocumentPositionParams, request.params) or {
 					return w.wrap_error(err)
 				}
-				w.write(ls.definition(params))
+				w.write(ls.definition(params) or { return w.wrap_error(err) })
 			}
 			'textDocument/typeDefinition' {
 				params := json.decode(lsp.TextDocumentPositionParams, request.params) or {
 					return w.wrap_error(err)
 				}
-				w.write(ls.type_definition(params))
+				w.write(ls.type_definition(params) or { return w.wrap_error(err) })
 			}
 			'textDocument/references' {
 				params := json.decode(lsp.ReferenceParams, request.params) or {
@@ -252,7 +256,7 @@ pub fn (mut ls LanguageServer) handle_jsonrpc(request &jsonrpc.Request, mut rw j
 				params := json.decode(lsp.TextDocumentPositionParams, request.params) or {
 					return w.wrap_error(err)
 				}
-				w.write(ls.implementation(params))
+				w.write(ls.implementation(params) or { return w.wrap_error(err) })
 			}
 			'workspace/didChangeWatchedFiles' {
 				params := json.decode(lsp.DidChangeWatchedFilesParams, request.params) or {
@@ -270,7 +274,7 @@ pub fn (mut ls LanguageServer) handle_jsonrpc(request &jsonrpc.Request, mut rw j
 				params := json.decode(lsp.InlayHintParams, request.params) or {
 					return w.wrap_error(err)
 				}
-				w.write(ls.inlay_hints(params))
+				w.write(ls.inlay_hints(params) or { return w.wrap_error(err) })
 			}
 			'textDocument/prepareRename' {
 				params := json.decode(lsp.PrepareRenameParams, request.params) or {
@@ -289,13 +293,17 @@ pub fn (mut ls LanguageServer) handle_jsonrpc(request &jsonrpc.Request, mut rw j
 				params := json.decode(lsp.SemanticTokensParams, request.params) or {
 					return w.wrap_error(err)
 				}
-				w.write(ls.semantic_tokens(params.text_document, lsp.Range{}))
+				w.write(ls.semantic_tokens(params.text_document, lsp.Range{}) or {
+					return w.wrap_error(err)
+				})
 			}
 			'textDocument/semanticTokens/range' {
 				params := json.decode(lsp.SemanticTokensRangeParams, request.params) or {
 					return w.wrap_error(err)
 				}
-				w.write(ls.semantic_tokens(params.text_document, params.range))
+				w.write(ls.semantic_tokens(params.text_document, params.range) or {
+					return w.wrap_error(err)
+				})
 			}
 			'textDocument/documentHighlight' {
 				params := json.decode(lsp.TextDocumentPositionParams, request.params) or {


### PR DESCRIPTION
For `none` values there is currently a redundant write. One inside the wrap_error function and one directly after it's return `handle_jsonrpc()`.

https://github.com/v-analyzer/v-analyzer/blob/012e7732614acf9ec75c0e5e774900da1313031e/server/ResponseWriter.v#L8-L15

https://github.com/v-analyzer/v-analyzer/blob/012e7732614acf9ec75c0e5e774900da1313031e/jsonrpc/server.v#L100-L104

Removing the double null write improves the recent fix of the NO_RESULT_CALLBACK error in neovim which gave some nice impulses to look into the related code. The change now restores the simplicity and slightly better performance of petrs original code while providing a fix.