### PR TITLE
docs: add wiki references for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,128 +24,16 @@ v-analyzer provides the following features:
 
 ## Installation
 
-### Linux and macOS
+Editor plugins:
 
-```
-v -e "$(curl -fsSL https://raw.githubusercontent.com/v-analyzer/v-analyzer/main/install.vsh)"
-```
+- [VS Code extension](https://github.com/v-analyzer/v-analyzer/wiki/editor-plugins#vscode)
+- [Neovim plugin](https://github.com/v-analyzer/v-analyzer/wiki/editor-plugins#neovim)
 
-### Windows
+Standalone binaries:
 
-The install.vsh file is downloaded to the current directory and stored there temporarily.
-So make sure that there is no file with this name or that it is safe when it is
-overwritten or deleted.
-
-#### Powershell
-
-```
-curl -o install.vsh https://raw.githubusercontent.com/v-analyzer/v-analyzer/main/install.vsh; v run install.vsh; del install.vsh
-```
-
-#### Command shell
-
-```
-curl -o install.vsh https://raw.githubusercontent.com/v-analyzer/v-analyzer/main/install.vsh && v run install.vsh && del install.vsh
-```
-
-## Pre-built binaries
-
-You can download pre-built binaries from the
-[release page](https://github.com/v-analyzer/v-analyzer/releases).
-Currently, we provide binaries for Linux (x64), macOS (x64 and ARM), and Windows (x64).
-
-## Building from source
-
-> **Note**
-> If you're using Windows, then you need GCC for any build, as TCC doesn't work
-> due to some issues.
-
-Update V to the latest version:
-
-```bash
-v up
-```
-
-Install dependencies:
-
-```bash
-v install
-```
-
-You can build debug or release version of the binary.
-Debug version will be slower, but faster to compile.
-
-Debug build:
-
-```bash
-v build.vsh debug
-```
-
-Release build:
-
-```bash
-v build.vsh release
-```
-
-Binary will be placed in `bin/` folder.
-
-## Setup
-
-Add `bin/` folder to your `$PATH` environment variable to use `v-analyzer`
-command inside VS Code and other editors (**preferred**).
-
-Or, you can specify the path to the binary in your VS Code settings:
-
-```json
-{
-  "v-analyzer.serverPath": "/path/to/v-analyzer/bin/v-analyzer"
-}
-```
-
-> **Note**
-> Restart VS Code after changing the settings or PATH.
-
-### Config
-
-v-analyzer is configured using global or local config.
-The global config is located in `~/.config/v-analyzer/config.toml`, changing it will affect all
-projects.
-
-A local config can be created with the `v-analyzer init` command at the root of the project.
-Once created, it will be in `./.v-analyzer/config.toml`.
-Each setting in the config has a detailed description.
-
-Pay attention to the `custom_vroot` setting, if v-analyzer cannot find where V was installed, then
-you will need to specify the path to it manually in this field.
-
-## Updating
-
-To update `v-analyzer` to the latest version, run:
-
-```bash
-v-analyzer up
-```
-
-You can also update to a nightly version:
-
-```bash
-v-analyzer up --nightly
-```
-
-> **Note**
-> In the nightly version you will get the latest changes, but they may not be stable!
-
-## VS Code extension
-
-This repository also contains the source code for the VS Code extension in the
-[`editors/code`](https://github.com/v-analyzer/v-analyzer/tree/main/editors/code)
-folder.
-It is also available via the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=VOSCA.vscode-v-analyzer).
-
-## NVIM LSP
-
-For Neovim users, v-analyzer is available via [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#v_analyzer).
-It is part of the mason registry and can be installated with `:LspInstall v_analyzer`.
+- [Webscript installation](https://github.com/v-analyzer/v-analyzer/wiki/binaries#webscript)
+- [Prebuilt releases](https://github.com/v-analyzer/v-analyzer/wiki/binaries#prebuilt)
+- [Build from source](https://github.com/v-analyzer/v-analyzer/wiki/binaries#build-from-source)
 
 ## Authors
 


### PR DESCRIPTION
This PR aims to simplify the readme to give a better overview of the installation methods.
Rendered preview: https://github.com/ttytm/v-analyzer/tree/docs/wiki#v-analyzer


**It is not intended to be merged if there is no wiki or similar resource.**
A wiki could also make it easier for the community to expand instructions and information such as setting up v-analyzer for other editors.
If a wiki is enabled I can offer to add readmes current instructions to it.

