### PR TITLE
ci: use `fail-fast:false` instead of `continue-on-error` to prevent false negatives

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -16,10 +16,10 @@ jobs:
           - os: ubuntu-20.04
           - os: macos-latest
           - os: windows-latest
+      fail-fast: false
 
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
 
     steps:
       - name: Install V


### PR DESCRIPTION
I think `fail-fast` is the setting that fits the intended use case better here than `continue-on-error` (I'm guessing the use case is to not interrupt other matrix CI).

- Current
  ![Screenshot_20231211_142349](https://github.com/v-analyzer/v-analyzer/assets/34311583/ac005d97-1947-4849-8edc-8d912aa1c687)

- Changed
  ![Screenshot_20231211_142930](https://github.com/v-analyzer/v-analyzer/assets/34311583/babd4184-b3f1-4029-8e8f-c302a4362a82)

