### PR TITLE
fix: enable exit method

### DIFF
--- a/server/language_server.v
+++ b/server/language_server.v
@@ -155,8 +155,7 @@ pub fn (mut ls LanguageServer) handle_jsonrpc(request &jsonrpc.Request, mut rw j
 				ls.initialized(mut rw)
 			}
 			'exit' {
-				// ignore for the reasons stated in the above comment
-				// ls.exit()
+				ls.exit()
 			}
 			'textDocument/didOpen' {
 				params := json.decode(lsp.DidOpenTextDocumentParams, request.params) or {


### PR DESCRIPTION
Not enabling the exit method results in v-analzyer not being ended when it should be.

E.g. when using neovim and ending an neovim instance, v-analyzer keeps running, and it's required to kill it manually to end its process. When using multiple neovim instances and exiting in and out, v-analyzer processes sum up up quickly and can consume a lot of memory. As with other servers, this should be done by default and should not require any manual intervention. 

![Screenshot_20231212_052409](https://github.com/v-analyzer/v-analyzer/assets/34311583/10d37ce9-ef3e-4720-8bea-f815406647c5)


Also `LspStop` and `LspRestart` commands require the the exit method to work. Currently the command do not work for v-analzyer. This is fixed by the PR.

There is a comment next to the currently commented out method.
> // ignore for the reasons stated in the above comment

But I can't find the mentioned reasons, so commenting it out might be outdated.