### PR TITLE
ci: add silent nightly releases

### DIFF
--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -6,12 +6,13 @@ on:
     branches:
       - main
     paths-ignore:
-      - '.github/**'
       - '**/test/**'
       - '**/tests/**'
-      - '**/*.md'
       - '**/test_*.v'
       - '**/*_test.v'
+      - '**/*.md'
+      - '.github/**'
+      - '!.github/nightly_release.yml'
 
 permissions:
   contents: write
@@ -41,6 +42,7 @@ jobs:
     env:
       CC: ${{ matrix.cc }}
       VFLAGS: ${{ matrix.vflags }}
+      ARTIFACT: v-analyzer-${{ matrix.target }}
 
     steps:
       - name: Install V
@@ -59,36 +61,32 @@ jobs:
           cd v-analyzer
           v run build.vsh release
 
-      - name: Create artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: v-analyzer-${{ matrix.target }}
+          name: ${{ env.ARTIFACT }}
           path: ./v-analyzer/bin/v-analyzer${{ matrix.bin_ext }}
 
-  nightly-release:
-    if: github.event.repository.full_name == 'v-analyzer/v-analyzer'
-    name: Create Nightly GitHub Release
-    needs: dist
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v3
-
-      - name: 'Create zip'
+      - name: Prepare release
         shell: bash
         run: |
-          chmod 755 v-analyzer-*/*
-          for name in $(ls -d v-analyzer-*); do
-            7z a -y -tzip -mx=9 -mtc=off -sdel -aoa $name $name/.
-            rm -rf $name
-          done
+          now=$(date -u +'%Y-%m-%d %H:%M:%S UTC')
+          echo "BODY=Generated on <samp>$now</samp> from commit ${{ github.sha }}." >> $GITHUB_ENV
+          7z a -tzip ${{ env.ARTIFACT }}.zip ./v-analyzer/bin/v-analyzer${{ matrix.bin_ext }}
 
-      - uses: marvinpinto/action-automatic-releases@latest
-        name: Create Release and Upload Assets
-        id: create_release
+      - name: Update Nightly Tag
+        uses: richardsimko/update-tag@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          automatic_release_tag: latest
+          tag_name: nightly
+
+      - name: Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: ${{ env.ARTIFACT }}.zip
+          tag: nightly
+          body: ${{ env.BODY }}
+          name: v-analyzer development build
           prerelease: true
-          title: nightly release
-          files: |
-            *.zip
+          allowUpdates: true

--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -74,7 +74,7 @@ jobs:
           echo "BODY=Generated on <samp>$now</samp> from commit ${{ github.sha }}." >> $GITHUB_ENV
           7z a -tzip ${{ env.ARTIFACT }}.zip ./v-analyzer/bin/v-analyzer${{ matrix.bin_ext }}
 
-      - name: Update Nightly Tag
+      - name: Update nightly tag
         uses: richardsimko/update-tag@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -12,7 +12,7 @@ on:
       - '**/*_test.v'
       - '**/*.md'
       - '.github/**'
-      - '!.github/nightly_release.yml'
+      - '!.github/workflows/nightly_release.yml'
 
 permissions:
   contents: write


### PR DESCRIPTION
With this PR nighlty releases will be silent. No more announcements will be created in a GitHub feed for every commit with a nightly release, but the tag and it's binaries will still be updated. The change is releated to what was commented in https://github.com/v-analyzer/v-analyzer/pull/64.

Releases tested on the fork: https://github.com/ttytm/v-analyzer/releases/nightly

A notable change: 
At current master, the tag used for nightly/pre-releases is `latest`.
This naming for a nightly release tag is a bit confusing. `latest` usually refers to the latest release that is not a pre-release. Latest releases for all github projects can be accessed via an url like the following https://github.com/v-analyzer/v-analyzer/releases/latest (this will open the lastest version release). An url like the one for the fork above, won't work for v-analyzer atm: https://github.com/v-analyzer/v-analyzer/releases/nightly. It will work after the PR.

To make it more conventional the changes set the pre-release tag to `nightly`. After merging the PR the tag should be created automatically. When that happened I recommend removing the current `latest` tag.
