### PR TITLE
fix: use gcc for building on windows

### DIFF
--- a/build.vsh
+++ b/build.vsh
@@ -34,7 +34,7 @@ fn (m ReleaseMode) compile_cmd() string {
 	} else {
 		$if windows {
 			// TCC cannot build tree-sitter on Windows.
-			'-cc ' + if _ := os.find_abs_path_of_executable('gcc') { 'gcc' } else { 'msvc' }
+			'-cc gcc'
 		} $else {
 			// Let `-prod` toggle the appropriate production compiler.
 			''


### PR DESCRIPTION
v-analyzer cannot be build on msvc on windows atm.

https://github.com/v-analyzer/v-analyzer/actions/runs/7221567521/job/19676795303

```
[ERROR] Failed to build v-analyzer
Building v-analyzer at commit: f[9](https://github.com/v-analyzer/v-analyzer/actions/runs/7221567521/job/19676795303#step:4:10)d5815, build time: 2023-12-15 11:40:47 ...
C:\hostedtoolcache\windows\v\0.4.3\x64\thirdparty\cJSON\cJSON.obj not found, building it (with msvc)...
✓ Prepared output directory
Building v-analyzer in release mode, using: C:\hostedtoolcache\windows\v\0.4.3\x64\v.exe ./cmd/v-analyzer -o ./bin/v-analyzer.exe -no-parallel -cc msvc  -prod

...

builder error: msvc error
```

The same issue happens for me when trying to build with msvc locally.

I should have checked better when adding msvc to the build script, sorry.