### PR TITLE
ci: remove matrix cc from nightly_release.yml, fix nightly builds

### DIFF
--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -32,6 +32,7 @@ jobs:
           - os: macos-latest
             target: darwin-arm64
             vflags: -d cross_compile_macos_arm64
+      fail-fast: false
 
     name: Build binary artifact for ${{ matrix.target }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -25,22 +25,17 @@ jobs:
           - os: windows-latest
             target: windows-x86_64
             bin_ext: .exe
-            cc: msvc
           - os: ubuntu-latest
             target: linux-x86_64
-            cc: gcc
           - os: macos-latest
             target: darwin-x86_64
-            cc: clang
           - os: macos-latest
             target: darwin-arm64
-            cc: clang
             vflags: -d cross_compile_macos_arm64
 
     name: Build binary artifact for ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     env:
-      CC: ${{ matrix.cc }}
       VFLAGS: ${{ matrix.vflags }}
       ARTIFACT: v-analyzer-${{ matrix.target }}
 


### PR DESCRIPTION
we can let the build script choose the compiler here.

The specifications that are removed here weren't used anyway before the recent update to the build script that now allows to set a custom CC.